### PR TITLE
Add animated preview all playback

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,6 +305,8 @@
         </div>
 
         <!-- Download button with text input for pack name -->
+        <div id="notificationContainer" class="fixed top-6 right-6 space-y-3 z-50"></div>
+
         <div class="text-center mb-10">
             <div class="flex flex-col md:flex-row md:items-center md:justify-center gap-3 max-w-2xl mx-auto">
                 <div class="relative flex-grow md:min-w-[280px]">
@@ -312,10 +314,6 @@
                 </div>
                 <div class="flex items-center justify-center gap-2">
                     <button id="previewAll" class="glow-button bg-white/10 hover:bg-white/15 text-white font-medium py-2.5 px-5 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-400 transition-all duration-300 ease-in-out transform flex items-center justify-center space-x-2 whitespace-nowrap">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                            <path fill-rule="evenodd" d="M4.5 4.5a1 1 0 011-1h2.036a1 1 0 01.832.445l1.3 1.942H15.5a1 1 0 011 1V9h-2V7.887H9.847a1 1 0 01-.832-.445L7.715 5.5H5.5V15h3v2h-3a1 1 0 01-1-1v-11z" clip-rule="evenodd" />
-                            <path d="M12 12.5a.5.5 0 01.79-.407l2.5 1.833a.5.5 0 010 .814l-2.5 1.833A.5.5 0 0112 16.166V12.5z" />
-                        </svg>
                         <span>Preview All Sounds</span>
                     </button>
                     <button id="downloadAll" class="glow-button bg-white/10 hover:bg-white/15 text-white font-medium py-2.5 px-5 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-400 transition-all duration-300 ease-in-out transform flex items-center justify-center space-x-2 whitespace-nowrap">

--- a/index.html
+++ b/index.html
@@ -181,30 +181,35 @@
         }
 
         .preview-wave {
-            display: inline-block;
+            display: block;
             width: 4px;
-            height: 12px;
+            height: 14px;
             border-radius: 9999px;
-            background: linear-gradient(to top, rgba(252, 211, 77, 0.9), rgba(249, 115, 22, 0.9));
-            animation: indicatorPulse 1.1s ease-in-out infinite;
+            background: linear-gradient(to top, rgba(252, 211, 77, 0.95), rgba(249, 115, 22, 0.9));
+            transform-origin: center bottom;
+            animation: previewWave 1.05s ease-in-out infinite;
         }
 
         .preview-wave:nth-child(2) {
-            animation-delay: 0.15s;
+            animation-delay: 0.14s;
         }
 
         .preview-wave:nth-child(3) {
-            animation-delay: 0.3s;
+            animation-delay: 0.28s;
         }
 
-        @keyframes indicatorPulse {
+        @keyframes previewWave {
             0%, 100% {
-                transform: scaleY(0.45);
+                transform: scaleY(0.35);
                 opacity: 0.55;
             }
-            50% {
-                transform: scaleY(1);
+            40% {
+                transform: scaleY(1.15);
                 opacity: 1;
+            }
+            60% {
+                transform: scaleY(0.75);
+                opacity: 0.85;
             }
         }
 
@@ -259,8 +264,9 @@
 
             .preview-wave {
                 animation: none;
-                transform: scaleY(0.7);
-                opacity: 0.8;
+                transform-origin: center bottom;
+                transform: scaleY(0.65);
+                opacity: 0.85;
             }
         }
     </style>

--- a/index.html
+++ b/index.html
@@ -52,10 +52,14 @@
             background-color: rgba(255, 255, 255, 0.08);
         }
 
+        :root {
+            --preview-animation-duration: 1.8s;
+        }
+
         .card-glass.previewing-all {
             border-color: rgba(96, 165, 250, 0.45);
             box-shadow: 0 0 22px rgba(59, 130, 246, 0.28);
-            animation: previewPulse 1.8s ease-in-out infinite;
+            animation: previewPulse var(--preview-animation-duration) ease-in-out infinite;
         }
 
         .card-glass.previewing-all::before {
@@ -65,7 +69,7 @@
             background: linear-gradient(135deg, rgba(59, 130, 246, 0.18), rgba(14, 165, 233, 0.1));
             opacity: 0.35;
             pointer-events: none;
-            animation: previewGlowOverlay 1.8s ease-in-out infinite;
+            animation: previewGlowOverlay var(--preview-animation-duration) ease-in-out infinite;
         }
 
         .input-file-style {
@@ -141,7 +145,7 @@
         }
 
         .glow-button.previewing-active {
-            animation: buttonPulse 1.8s ease-in-out infinite;
+            animation: buttonPulse var(--preview-animation-duration) ease-in-out infinite;
             box-shadow: 0 0 18px rgba(96, 165, 250, 0.4);
         }
 

--- a/index.html
+++ b/index.html
@@ -54,11 +54,15 @@
 
         :root {
             --preview-animation-duration: 1.8s;
+            --preview-accent: #f97316;
+            --preview-accent-bright: #fb923c;
+            --preview-accent-shadow: rgba(249, 115, 22, 0.28);
+            --preview-accent-shadow-strong: rgba(249, 115, 22, 0.46);
         }
 
         .card-glass.previewing-all {
-            border-color: rgba(96, 165, 250, 0.45);
-            box-shadow: 0 0 22px rgba(59, 130, 246, 0.28);
+            border-color: rgba(249, 115, 22, 0.55);
+            box-shadow: 0 0 22px var(--preview-accent-shadow);
             animation: previewPulse var(--preview-animation-duration) ease-in-out infinite;
         }
 
@@ -66,7 +70,7 @@
             content: '';
             position: absolute;
             inset: -1px;
-            background: linear-gradient(135deg, rgba(59, 130, 246, 0.18), rgba(14, 165, 233, 0.1));
+            background: linear-gradient(135deg, rgba(249, 115, 22, 0.22), rgba(17, 17, 17, 0.4));
             opacity: 0.35;
             pointer-events: none;
             animation: previewGlowOverlay var(--preview-animation-duration) ease-in-out infinite;
@@ -146,7 +150,7 @@
 
         .glow-button.previewing-active {
             animation: buttonPulse var(--preview-animation-duration) ease-in-out infinite;
-            box-shadow: 0 0 18px rgba(96, 165, 250, 0.4);
+            box-shadow: 0 0 18px var(--preview-accent-shadow-strong);
         }
 
         .glow-button:disabled {
@@ -156,10 +160,24 @@
             transform: none;
         }
 
+        .preview-status-region {
+            min-height: 3rem;
+        }
+
         .preview-all-indicator {
-            background: rgba(37, 99, 235, 0.25);
-            border: 1px solid rgba(191, 219, 254, 0.45);
-            box-shadow: 0 8px 18px rgba(59, 130, 246, 0.25);
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            background: rgba(249, 115, 22, 0.18);
+            border: 1px solid rgba(251, 146, 60, 0.45);
+            box-shadow: 0 12px 28px rgba(249, 115, 22, 0.32);
+            color: #ffedd5;
+            text-transform: uppercase;
+            letter-spacing: 0.12em;
+            font-weight: 600;
+            font-size: 0.7rem;
+            border-radius: 0.85rem;
+            padding: 0.45rem 0.75rem;
         }
 
         .preview-wave {
@@ -167,7 +185,7 @@
             width: 4px;
             height: 12px;
             border-radius: 9999px;
-            background: linear-gradient(to top, rgba(191, 219, 254, 0.9), rgba(59, 130, 246, 0.9));
+            background: linear-gradient(to top, rgba(252, 211, 77, 0.9), rgba(249, 115, 22, 0.9));
             animation: indicatorPulse 1.1s ease-in-out infinite;
         }
 
@@ -193,22 +211,22 @@
         @keyframes previewPulse {
             0%, 100% {
                 transform: translateY(0);
-                box-shadow: 0 0 18px rgba(59, 130, 246, 0.18);
+                box-shadow: 0 0 18px var(--preview-accent-shadow);
             }
             50% {
                 transform: translateY(-4px);
-                box-shadow: 0 0 34px rgba(59, 130, 246, 0.38);
+                box-shadow: 0 0 34px var(--preview-accent-shadow-strong);
             }
         }
 
         @keyframes buttonPulse {
             0%, 100% {
                 transform: translateY(0);
-                box-shadow: 0 0 16px rgba(59, 130, 246, 0.24);
+                box-shadow: 0 0 16px var(--preview-accent-shadow);
             }
             50% {
                 transform: translateY(-2px);
-                box-shadow: 0 0 26px rgba(59, 130, 246, 0.44);
+                box-shadow: 0 0 26px var(--preview-accent-shadow-strong);
             }
         }
 
@@ -225,7 +243,7 @@
             .card-glass.previewing-all {
                 animation: none;
                 transform: none;
-                box-shadow: 0 0 22px rgba(59, 130, 246, 0.28);
+                box-shadow: 0 0 22px var(--preview-accent-shadow);
             }
 
             .card-glass.previewing-all::before {
@@ -236,7 +254,7 @@
             .glow-button.previewing-active {
                 animation: none;
                 transform: none;
-                box-shadow: 0 0 18px rgba(96, 165, 250, 0.4);
+                box-shadow: 0 0 18px var(--preview-accent-shadow-strong);
             }
 
             .preview-wave {

--- a/index.html
+++ b/index.html
@@ -220,6 +220,31 @@
                 opacity: 0.55;
             }
         }
+
+        @media (prefers-reduced-motion: reduce) {
+            .card-glass.previewing-all {
+                animation: none;
+                transform: none;
+                box-shadow: 0 0 22px rgba(59, 130, 246, 0.28);
+            }
+
+            .card-glass.previewing-all::before {
+                animation: none;
+                opacity: 0.35;
+            }
+
+            .glow-button.previewing-active {
+                animation: none;
+                transform: none;
+                box-shadow: 0 0 18px rgba(96, 165, 250, 0.4);
+            }
+
+            .preview-wave {
+                animation: none;
+                transform: scaleY(0.7);
+                opacity: 0.8;
+            }
+        }
     </style>
     <script>
         // Preload background image for smoother experience
@@ -309,7 +334,7 @@
         </div>
 
         <!-- Download button with text input for pack name -->
-        <div id="notificationContainer" class="fixed top-6 right-6 space-y-3 z-50"></div>
+        <div id="notificationContainer" class="fixed top-6 right-6 space-y-3 z-[75]"></div>
 
         <div class="text-center mb-10">
             <div class="flex flex-col md:flex-row md:items-center md:justify-center gap-3 max-w-2xl mx-auto">

--- a/index.html
+++ b/index.html
@@ -38,6 +38,8 @@
         }
 
         .card-glass {
+            position: relative;
+            overflow: hidden;
             background-color: rgba(255, 255, 255, 0.06);
             border: 1px solid rgba(255, 255, 255, 0.1);
             backdrop-filter: blur(16px);
@@ -48,6 +50,22 @@
             box-shadow: 0 0 12px rgba(80, 150, 255, 0.25);
             transform: scale(1.01);
             background-color: rgba(255, 255, 255, 0.08);
+        }
+
+        .card-glass.previewing-all {
+            border-color: rgba(96, 165, 250, 0.45);
+            box-shadow: 0 0 22px rgba(59, 130, 246, 0.28);
+            animation: previewPulse 1.8s ease-in-out infinite;
+        }
+
+        .card-glass.previewing-all::before {
+            content: '';
+            position: absolute;
+            inset: -1px;
+            background: linear-gradient(135deg, rgba(59, 130, 246, 0.18), rgba(14, 165, 233, 0.1));
+            opacity: 0.35;
+            pointer-events: none;
+            animation: previewGlowOverlay 1.8s ease-in-out infinite;
         }
 
         .input-file-style {
@@ -120,6 +138,83 @@
 
         .instruction-content.expanded {
             max-height: 1000px; /* This value needs to be larger than the content height */
+        }
+
+        .glow-button.previewing-active {
+            animation: buttonPulse 1.8s ease-in-out infinite;
+            box-shadow: 0 0 18px rgba(96, 165, 250, 0.4);
+        }
+
+        .glow-button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+            box-shadow: none;
+            transform: none;
+        }
+
+        .preview-all-indicator {
+            background: rgba(37, 99, 235, 0.25);
+            border: 1px solid rgba(191, 219, 254, 0.45);
+            box-shadow: 0 8px 18px rgba(59, 130, 246, 0.25);
+        }
+
+        .preview-wave {
+            display: inline-block;
+            width: 4px;
+            height: 12px;
+            border-radius: 9999px;
+            background: linear-gradient(to top, rgba(191, 219, 254, 0.9), rgba(59, 130, 246, 0.9));
+            animation: indicatorPulse 1.1s ease-in-out infinite;
+        }
+
+        .preview-wave:nth-child(2) {
+            animation-delay: 0.15s;
+        }
+
+        .preview-wave:nth-child(3) {
+            animation-delay: 0.3s;
+        }
+
+        @keyframes indicatorPulse {
+            0%, 100% {
+                transform: scaleY(0.45);
+                opacity: 0.55;
+            }
+            50% {
+                transform: scaleY(1);
+                opacity: 1;
+            }
+        }
+
+        @keyframes previewPulse {
+            0%, 100% {
+                transform: translateY(0);
+                box-shadow: 0 0 18px rgba(59, 130, 246, 0.18);
+            }
+            50% {
+                transform: translateY(-4px);
+                box-shadow: 0 0 34px rgba(59, 130, 246, 0.38);
+            }
+        }
+
+        @keyframes buttonPulse {
+            0%, 100% {
+                transform: translateY(0);
+                box-shadow: 0 0 16px rgba(59, 130, 246, 0.24);
+            }
+            50% {
+                transform: translateY(-2px);
+                box-shadow: 0 0 26px rgba(59, 130, 246, 0.44);
+            }
+        }
+
+        @keyframes previewGlowOverlay {
+            0%, 100% {
+                opacity: 0.25;
+            }
+            50% {
+                opacity: 0.55;
+            }
         }
     </style>
     <script>
@@ -211,16 +306,25 @@
 
         <!-- Download button with text input for pack name -->
         <div class="text-center mb-10">
-            <div class="flex items-center justify-center space-x-3 max-w-xl mx-auto">
-                <div class="relative flex-grow">
+            <div class="flex flex-col md:flex-row md:items-center md:justify-center gap-3 max-w-2xl mx-auto">
+                <div class="relative flex-grow md:min-w-[280px]">
                     <input type="text" id="packName" placeholder="Enter sound pack name" class="w-full py-2.5 px-4 rounded-xl bg-white/10 border border-white/10 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-400 text-white placeholder-gray-400 transition-all duration-300">
                 </div>
-                <button id="downloadAll" class="glow-button bg-white/10 hover:bg-white/15 text-white font-medium py-2.5 px-5 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-400 transition-all duration-300 ease-in-out transform flex items-center justify-center space-x-2 whitespace-nowrap">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                        <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd" />
-                    </svg>
-                    <span>Download Sound Pack</span>
-                </button>
+                <div class="flex items-center justify-center gap-2">
+                    <button id="previewAll" class="glow-button bg-white/10 hover:bg-white/15 text-white font-medium py-2.5 px-5 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-400 transition-all duration-300 ease-in-out transform flex items-center justify-center space-x-2 whitespace-nowrap">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                            <path fill-rule="evenodd" d="M4.5 4.5a1 1 0 011-1h2.036a1 1 0 01.832.445l1.3 1.942H15.5a1 1 0 011 1V9h-2V7.887H9.847a1 1 0 01-.832-.445L7.715 5.5H5.5V15h3v2h-3a1 1 0 01-1-1v-11z" clip-rule="evenodd" />
+                            <path d="M12 12.5a.5.5 0 01.79-.407l2.5 1.833a.5.5 0 010 .814l-2.5 1.833A.5.5 0 0112 16.166V12.5z" />
+                        </svg>
+                        <span>Preview All Sounds</span>
+                    </button>
+                    <button id="downloadAll" class="glow-button bg-white/10 hover:bg-white/15 text-white font-medium py-2.5 px-5 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-400 transition-all duration-300 ease-in-out transform flex items-center justify-center space-x-2 whitespace-nowrap">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                            <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd" />
+                        </svg>
+                        <span>Download Sound Pack</span>
+                    </button>
+                </div>
             </div>
         </div>
 

--- a/index.js
+++ b/index.js
@@ -507,6 +507,18 @@ function createAudioEventElement(file) {
                 </button>
             </div>
             <p class="text-sm text-gray-300 mb-4 opacity-80">${file.description}</p>
+            <div class="preview-status-region flex items-center justify-center mb-4">
+                <div class="preview-all-indicator hidden backdrop-blur-sm" role="status" aria-live="polite" aria-label="Currently previewing sound">
+                    <div class="flex items-center gap-2">
+                        <span class="flex items-end gap-[3px]" aria-hidden="true">
+                            <span class="preview-wave"></span>
+                            <span class="preview-wave"></span>
+                            <span class="preview-wave"></span>
+                        </span>
+                        <span>Now Playing</span>
+                    </div>
+                </div>
+            </div>
             <div id="fileInputsContainer_${file.name}" class="min-h-[120px]">
                 <div id="fileInputs_${file.name}" class="space-y-3">
                     <div id="singleInput_${file.name}">
@@ -547,23 +559,6 @@ function createAudioEventElement(file) {
     fileBox.querySelectorAll('input[type="file"]').forEach(input => {
         input.className = 'input-file-style block w-full text-xs text-gray-300 cursor-pointer';
     });
-
-    const previewIndicator = document.createElement('div');
-    previewIndicator.className = 'preview-all-indicator hidden absolute top-4 right-4 px-2 py-1 rounded-lg text-[11px] font-semibold uppercase tracking-wide text-blue-100 backdrop-blur-sm';
-    previewIndicator.setAttribute('aria-label', 'Currently previewing sound');
-    previewIndicator.setAttribute('role', 'status');
-    previewIndicator.setAttribute('aria-live', 'polite');
-    previewIndicator.innerHTML = `
-        <div class="flex items-center gap-1.5">
-            <span class="flex items-center gap-[3px]">
-                <span class="preview-wave"></span>
-                <span class="preview-wave"></span>
-                <span class="preview-wave"></span>
-            </span>
-            <span>Previewing</span>
-        </div>
-    `;
-    fileBox.appendChild(previewIndicator);
 
     // Get references to elements
     const sameAudioCheckbox = fileBox.querySelector(`#same_${file.name}`);

--- a/index.js
+++ b/index.js
@@ -48,7 +48,212 @@ const audioFiles = [
 
 const fileContainer = document.getElementById('fileContainer');
 const downloadAllButton = document.getElementById('downloadAll');
+const previewAllButton = document.getElementById('previewAll');
 const uploadedFiles = {};
+const cardElements = {};
+
+const previewAllPlayIcon = `
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M4.5 4.5a1 1 0 011-1h2.036a1 1 0 01.832.445l1.3 1.942H15.5a1 1 0 011 1V9h-2V7.887H9.847a1 1 0 01-.832-.445L7.715 5.5H5.5V15h3v2h-3a1 1 0 01-1-1v-11z" clip-rule="evenodd" />
+        <path d="M12 12.5a.5.5 0 01.79-.407l2.5 1.833a.5.5 0 010 .814l-2.5 1.833A.5.5 0 0112 16.166V12.5z" />
+    </svg>
+`;
+
+const previewAllStopIcon = `
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M6 5a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V6a1 1 0 00-1-1H6z" clip-rule="evenodd" />
+    </svg>
+`;
+
+const previewAllController = {
+    isPlaying: false,
+    queue: [],
+    currentAudio: null,
+    currentUrl: null,
+    currentEvent: null,
+    resolveCurrent: null
+};
+
+function updatePreviewAllAvailability() {
+    if (!previewAllButton) return;
+    const hasAnyAudio = audioFiles.some(file => uploadedFiles[`D_${file.name}`] || uploadedFiles[`F_${file.name}`]);
+
+    if (!hasAnyAudio && previewAllController.isPlaying) {
+        stopPreviewAll();
+    }
+
+    previewAllButton.disabled = !hasAnyAudio;
+    previewAllButton.setAttribute('aria-disabled', String(!hasAnyAudio));
+}
+
+function setPreviewAllButtonState(state) {
+    if (!previewAllButton) return;
+    if (state === 'playing') {
+        previewAllButton.innerHTML = `${previewAllStopIcon}<span>Stop Preview</span>`;
+        previewAllButton.classList.add('previewing-active');
+        previewAllButton.setAttribute('aria-pressed', 'true');
+    } else {
+        previewAllButton.innerHTML = `${previewAllPlayIcon}<span>Preview All Sounds</span>`;
+        previewAllButton.classList.remove('previewing-active');
+        previewAllButton.setAttribute('aria-pressed', 'false');
+    }
+}
+
+function clearAllCardPreviewing() {
+    Object.values(cardElements).forEach(card => {
+        card.classList.remove('previewing-all');
+        const indicator = card.querySelector('.preview-all-indicator');
+        if (indicator) {
+            indicator.classList.add('hidden');
+        }
+        const previewButtonElement = card.querySelector('.preview-button');
+        if (previewButtonElement) {
+            previewButtonElement.classList.remove('animate-pulse');
+        }
+    });
+}
+
+function setCardPreviewing(eventName, isPreviewing) {
+    const card = cardElements[eventName];
+    if (!card) return;
+
+    card.classList.toggle('previewing-all', isPreviewing);
+
+    const indicator = card.querySelector('.preview-all-indicator');
+    if (indicator) {
+        indicator.classList.toggle('hidden', !isPreviewing);
+    }
+
+    const previewButtonElement = card.querySelector('.preview-button');
+    if (previewButtonElement) {
+        previewButtonElement.classList.toggle('animate-pulse', isPreviewing);
+    }
+}
+
+function buildPreviewQueue() {
+    return audioFiles
+        .map(file => {
+            const candidate = uploadedFiles[`D_${file.name}`] || uploadedFiles[`F_${file.name}`];
+            if (!candidate) return null;
+            return { eventName: file.name, file: candidate };
+        })
+        .filter(Boolean);
+}
+
+function stopPreviewAll() {
+    previewAllController.isPlaying = false;
+
+    if (previewAllController.currentAudio) {
+        previewAllController.currentAudio.pause();
+        previewAllController.currentAudio.currentTime = 0;
+    }
+
+    if (typeof previewAllController.resolveCurrent === 'function') {
+        const resolver = previewAllController.resolveCurrent;
+        previewAllController.resolveCurrent = null;
+        resolver();
+    }
+
+    if (previewAllController.currentUrl) {
+        URL.revokeObjectURL(previewAllController.currentUrl);
+        previewAllController.currentUrl = null;
+    }
+
+    previewAllController.currentAudio = null;
+    previewAllController.currentEvent = null;
+    previewAllController.queue = [];
+
+    clearAllCardPreviewing();
+    setPreviewAllButtonState('idle');
+    updatePreviewAllAvailability();
+}
+
+function playPreviewItem(eventName, file) {
+    return new Promise(resolve => {
+        if (!previewAllController.isPlaying) {
+            resolve();
+            return;
+        }
+
+        const objectUrl = URL.createObjectURL(file);
+        const audio = new Audio(objectUrl);
+
+        previewAllController.currentAudio = audio;
+        previewAllController.currentUrl = objectUrl;
+        previewAllController.currentEvent = eventName;
+
+        let resolved = false;
+
+        const finish = () => {
+            if (resolved) return;
+            resolved = true;
+
+            setCardPreviewing(eventName, false);
+
+            audio.pause();
+            audio.currentTime = 0;
+
+            URL.revokeObjectURL(objectUrl);
+
+            if (previewAllController.currentAudio === audio) {
+                previewAllController.currentAudio = null;
+                previewAllController.currentUrl = null;
+                previewAllController.currentEvent = null;
+            }
+
+            previewAllController.resolveCurrent = null;
+            resolve();
+        };
+
+        previewAllController.resolveCurrent = finish;
+
+        audio.addEventListener('ended', finish, { once: true });
+        audio.addEventListener('error', finish, { once: true });
+
+        setCardPreviewing(eventName, true);
+
+        const playPromise = audio.play();
+        if (playPromise && typeof playPromise.catch === 'function') {
+            playPromise.catch(() => finish());
+        }
+    });
+}
+
+async function handlePreviewAllClick(event) {
+    if (event) event.preventDefault();
+    if (!previewAllButton || previewAllButton.disabled) {
+        return;
+    }
+
+    if (previewAllController.isPlaying) {
+        stopPreviewAll();
+        return;
+    }
+
+    const queue = buildPreviewQueue();
+    if (queue.length === 0) {
+        alert('Add at least one sound file to preview.');
+        return;
+    }
+
+    previewAllController.isPlaying = true;
+    previewAllController.queue = queue;
+    setPreviewAllButtonState('playing');
+    clearAllCardPreviewing();
+
+    for (const item of queue) {
+        if (!previewAllController.isPlaying) {
+            break;
+        }
+        await playPreviewItem(item.eventName, item.file);
+    }
+
+    if (previewAllController.isPlaying) {
+        previewAllController.isPlaying = false;
+    }
+
+    stopPreviewAll();
+}
 
 // Audio conversion utilities
 const audioUtils = {
@@ -193,6 +398,8 @@ function createAudioEventElement(file) {
     let audioPlayer = null; // To hold the audio element for preview
     let currentPreviewFile = null; // To track which file is loaded in the player
 
+    fileBox.dataset.eventName = file.name;
+
     fileBox.innerHTML = `
         <div>
             <div class="flex justify-between items-center mb-3">
@@ -249,6 +456,20 @@ function createAudioEventElement(file) {
     fileBox.querySelectorAll('input[type="file"]').forEach(input => {
         input.className = 'input-file-style block w-full text-xs text-gray-300 cursor-pointer';
     });
+
+    const previewIndicator = document.createElement('div');
+    previewIndicator.className = 'preview-all-indicator hidden absolute top-4 right-4 px-2 py-1 rounded-lg text-[11px] font-semibold uppercase tracking-wide text-blue-100 backdrop-blur-sm';
+    previewIndicator.innerHTML = `
+        <div class="flex items-center gap-1.5">
+            <span class="flex items-center gap-[3px]">
+                <span class="preview-wave"></span>
+                <span class="preview-wave"></span>
+                <span class="preview-wave"></span>
+            </span>
+            <span>Previewing</span>
+        </div>
+    `;
+    fileBox.appendChild(previewIndicator);
 
     // Get references to elements
     const sameAudioCheckbox = fileBox.querySelector(`#same_${file.name}`);
@@ -310,6 +531,8 @@ function createAudioEventElement(file) {
             audioPlayer = null;
             currentPreviewFile = null;
         }
+
+        updatePreviewAllAvailability();
     }
 
     // Event listener for the checkbox - INVERTED LOGIC
@@ -412,6 +635,7 @@ function createAudioEventElement(file) {
 
     // Initial setup for filename display
     updateFileNameDisplays();
+    updatePreviewAllAvailability();
 
     return fileBox;
 }
@@ -420,7 +644,15 @@ function createAudioEventElement(file) {
 audioFiles.forEach(file => {
     const fileElement = createAudioEventElement(file);
     fileContainer.appendChild(fileElement);
+    cardElements[file.name] = fileElement;
 });
+
+setPreviewAllButtonState('idle');
+updatePreviewAllAvailability();
+
+if (previewAllButton) {
+    previewAllButton.addEventListener('click', handlePreviewAllClick);
+}
 
 // Event listener for the download button
 downloadAllButton.addEventListener('click', async () => {

--- a/index.js
+++ b/index.js
@@ -182,6 +182,7 @@ function setCardPreviewing(eventName, isPreviewing) {
 }
 
 function buildPreviewQueue() {
+    // Prioritize desktop audio; if unavailable, use fullscreen audio
     return audioFiles
         .map(file => {
             const candidate = uploadedFiles[`D_${file.name}`] || uploadedFiles[`F_${file.name}`];


### PR DESCRIPTION
## Summary
- add a Preview All Sounds control next to the download button with new animated styles
- implement a controller to sequentially play every uploaded sound and highlight cards during playback
- surface visual indicators and disable the preview control when no audio is available

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_690a94021ae483228bf2e6181f77c8b5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Preview All Sounds" to sequentially play selected audio with queue-aware playback and per-file visual indicators; play/stop controls and sequential error handling.
  * In-app notifications replace browser alerts (styled, auto-dismiss, hover-to-pause).

* **Style**
  * Responsive layout showing Preview and Download actions side-by-side or stacked.
  * New animations and visual states for active previewing, buttons, and preview overlays.

* **Bug Fixes**
  * Improved handling and previewing of converted/uploaded audio with clearer error feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->