### PR TITLE
Add animated glow styling to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,11 +79,64 @@
         }
 
         .title-gradient {
-            background: linear-gradient(to bottom, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0.7));
+            background: linear-gradient(120deg, rgba(173, 216, 255, 1) 0%, rgba(255, 255, 255, 0.85) 50%, rgba(173, 216, 255, 1) 100%);
             -webkit-background-clip: text;
             background-clip: text;
             -webkit-text-fill-color: transparent;
             text-fill-color: transparent;
+        }
+
+        .title-glow {
+            position: relative;
+            text-shadow: 0 0 12px rgba(80, 150, 255, 0.45), 0 0 28px rgba(80, 150, 255, 0.35);
+            animation: titlePulse 6s ease-in-out infinite;
+        }
+
+        .title-glow::after {
+            content: "";
+            position: absolute;
+            inset: -8px 0 0 0;
+            z-index: -1;
+            opacity: 0.25;
+            background: radial-gradient(circle at top, rgba(80, 150, 255, 0.6), transparent 65%);
+            filter: blur(20px);
+            animation: haloDrift 12s ease-in-out infinite;
+        }
+
+        .logo-glow {
+            filter: drop-shadow(0 0 12px rgba(80, 150, 255, 0.45));
+            animation: logoPulse 5s ease-in-out infinite;
+        }
+
+        @keyframes titlePulse {
+            0%, 100% {
+                text-shadow: 0 0 12px rgba(80, 150, 255, 0.45), 0 0 28px rgba(80, 150, 255, 0.35);
+            }
+            50% {
+                text-shadow: 0 0 18px rgba(120, 200, 255, 0.6), 0 0 36px rgba(120, 200, 255, 0.45);
+            }
+        }
+
+        @keyframes haloDrift {
+            0%, 100% {
+                transform: translateY(0) scale(1);
+                opacity: 0.25;
+            }
+            50% {
+                transform: translateY(6px) scale(1.05);
+                opacity: 0.4;
+            }
+        }
+
+        @keyframes logoPulse {
+            0%, 100% {
+                transform: scale(1);
+                filter: drop-shadow(0 0 10px rgba(80, 150, 255, 0.4));
+            }
+            50% {
+                transform: scale(1.03) translateY(-1px);
+                filter: drop-shadow(0 0 18px rgba(120, 200, 255, 0.55));
+            }
         }
 
         .instruction-card {
@@ -161,8 +214,8 @@
     <div class="shader-overlay"></div>
     <div class="max-w-6xl mx-auto px-4 py-12 relative">
         <div class="flex items-center justify-center mb-12">
-            <img src="assets/playnite-optimized.png" alt="Playnite Logo" class="w-12 h-12 mr-4 drop-shadow-lg">
-            <h1 class="text-4xl font-bold text-white">Playnite Sounds Helper</h1>
+            <img src="assets/playnite-optimized.png" alt="Playnite Logo" class="w-12 h-12 mr-4 drop-shadow-lg logo-glow">
+            <h1 class="text-4xl font-bold text-white title-gradient title-glow">Playnite Sounds Helper</h1>
         </div>
 
         <!-- Collapsible instruction card -->

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
         }
 
         .card-glass:hover {
-            box-shadow: 0 0 12px rgba(80, 150, 255, 0.25);
+            box-shadow: 0 0 12px rgba(255, 149, 0, 0.3);
             transform: scale(1.01);
             background-color: rgba(255, 255, 255, 0.08);
         }
@@ -74,12 +74,12 @@
         }
 
         .glow-button:hover {
-            box-shadow: 0 0 15px rgba(66, 153, 225, 0.4);
+            box-shadow: 0 0 15px rgba(255, 149, 0, 0.45);
             transform: translateY(-1px);
         }
 
         .title-gradient {
-            background: linear-gradient(120deg, rgba(173, 216, 255, 1) 0%, rgba(255, 255, 255, 0.85) 50%, rgba(173, 216, 255, 1) 100%);
+            background: linear-gradient(120deg, rgba(255, 171, 64, 1) 0%, rgba(255, 204, 128, 0.9) 45%, rgba(255, 111, 0, 1) 100%);
             -webkit-background-clip: text;
             background-clip: text;
             -webkit-text-fill-color: transparent;
@@ -88,7 +88,7 @@
 
         .title-glow {
             position: relative;
-            text-shadow: 0 0 12px rgba(80, 150, 255, 0.45), 0 0 28px rgba(80, 150, 255, 0.35);
+            text-shadow: 0 0 12px rgba(255, 149, 0, 0.5), 0 0 28px rgba(255, 111, 0, 0.35);
             animation: titlePulse 6s ease-in-out infinite;
         }
 
@@ -98,22 +98,22 @@
             inset: -8px 0 0 0;
             z-index: -1;
             opacity: 0.25;
-            background: radial-gradient(circle at top, rgba(80, 150, 255, 0.6), transparent 65%);
+            background: radial-gradient(circle at top, rgba(255, 149, 0, 0.6), transparent 65%);
             filter: blur(20px);
             animation: haloDrift 12s ease-in-out infinite;
         }
 
         .logo-glow {
-            filter: drop-shadow(0 0 12px rgba(80, 150, 255, 0.45));
+            filter: drop-shadow(0 0 12px rgba(255, 149, 0, 0.45));
             animation: logoPulse 5s ease-in-out infinite;
         }
 
         @keyframes titlePulse {
             0%, 100% {
-                text-shadow: 0 0 12px rgba(80, 150, 255, 0.45), 0 0 28px rgba(80, 150, 255, 0.35);
+                text-shadow: 0 0 12px rgba(255, 149, 0, 0.5), 0 0 28px rgba(255, 111, 0, 0.35);
             }
             50% {
-                text-shadow: 0 0 18px rgba(120, 200, 255, 0.6), 0 0 36px rgba(120, 200, 255, 0.45);
+                text-shadow: 0 0 18px rgba(255, 184, 77, 0.65), 0 0 36px rgba(255, 140, 0, 0.45);
             }
         }
 
@@ -131,12 +131,22 @@
         @keyframes logoPulse {
             0%, 100% {
                 transform: scale(1);
-                filter: drop-shadow(0 0 10px rgba(80, 150, 255, 0.4));
+                filter: drop-shadow(0 0 10px rgba(255, 149, 0, 0.45));
             }
             50% {
                 transform: scale(1.03) translateY(-1px);
-                filter: drop-shadow(0 0 18px rgba(120, 200, 255, 0.55));
+                filter: drop-shadow(0 0 18px rgba(255, 184, 77, 0.6));
             }
+        }
+
+        .icon-accent {
+            color: #ff9626;
+            filter: drop-shadow(0 0 6px rgba(255, 149, 0, 0.35));
+            transition: filter 0.3s ease;
+        }
+
+        .icon-accent:hover {
+            filter: drop-shadow(0 0 10px rgba(255, 184, 77, 0.45));
         }
 
         .instruction-card {
@@ -223,7 +233,7 @@
             <div class="flex justify-between items-center mb-4">
                 <h2 class="text-xl font-semibold title-gradient">How to Install Sound Packs</h2>
                 <button id="toggleInstructions" class="w-8 h-8 flex items-center justify-center bg-white/10 hover:bg-white/20 rounded-full text-white transition-all duration-200 ease-in-out">
-                    <svg id="chevronIcon" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                    <svg id="chevronIcon" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 icon-accent" viewBox="0 0 20 20" fill="currentColor">
                         <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
                     </svg>
                 </button>
@@ -251,11 +261,12 @@
                     </div>
 
                     <div class="mt-4 pt-4 border-t border-white/10">
-                        <p class="text-sm text-gray-300">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline-block mr-1" viewBox="0 0 20 20" fill="currentColor">
+                        <p class="text-sm text-gray-300 flex items-center gap-2">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 icon-accent flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
                                 <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
                             </svg>
-                            <span>The Playnite Sounds Mod is a fork of the original abandoned extension. You can find it here: <a href="https://github.com/ashpynov/PlayniteSound" class="text-blue-400 hover:text-blue-300" target="_blank" rel="noopener">https://github.com/ashpynov/PlayniteSound</a></span>
+                            <span>The Playnite Sounds Mod is a fork of the original abandoned extension. You can find it here:</span>
+                            <a href="https://github.com/ashpynov/PlayniteSound" class="text-[#ff9626] hover:text-[#ffb347]" target="_blank" rel="noopener">https://github.com/ashpynov/PlayniteSound</a>
                         </p>
                     </div>
                 </div>
@@ -266,10 +277,10 @@
         <div class="text-center mb-10">
             <div class="flex items-center justify-center space-x-3 max-w-xl mx-auto">
                 <div class="relative flex-grow">
-                    <input type="text" id="packName" placeholder="Enter sound pack name" class="w-full py-2.5 px-4 rounded-xl bg-white/10 border border-white/10 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-400 text-white placeholder-gray-400 transition-all duration-300">
+                    <input type="text" id="packName" placeholder="Enter sound pack name" class="w-full py-2.5 px-4 rounded-xl bg-white/10 border border-white/10 focus:border-[#ff9626] focus:outline-none focus:ring-2 focus:ring-[#ff9626] text-white placeholder-gray-400 transition-all duration-300">
                 </div>
-                <button id="downloadAll" class="glow-button bg-white/10 hover:bg-white/15 text-white font-medium py-2.5 px-5 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-400 transition-all duration-300 ease-in-out transform flex items-center justify-center space-x-2 whitespace-nowrap">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                <button id="downloadAll" class="glow-button bg-white/10 hover:bg-white/15 text-white font-medium py-2.5 px-5 rounded-xl focus:outline-none focus:ring-2 focus:ring-[#ff9626] transition-all duration-300 ease-in-out transform flex items-center justify-center space-x-2 whitespace-nowrap">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 icon-accent" viewBox="0 0 20 20" fill="currentColor">
                         <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd" />
                     </svg>
                     <span>Download Sound Pack</span>


### PR DESCRIPTION
## Summary
- add gradient glow styling and animated halo for the Playnite Sounds Helper title
- pulse the Playnite icon with a coordinated drop-shadow animation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690adff39d5083228ac191294da800cd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced header visuals with new decorative glowing effects and smooth animations applied to the title and logo elements for a more refined and polished appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->